### PR TITLE
Pass integer to linspace

### DIFF
--- a/dirspec.py
+++ b/dirspec.py
@@ -99,7 +99,7 @@ def dirspec(ID, SM, EP, Options_=None):
     print('wavenumbers')
     wns = wavenumber(2  * np.pi * F, ID['depth'] * np.ones(np.shape(F)))
     pidirs = np.linspace(-np.pi, np.pi - 2 * np.pi / EP['dres'], 
-        num=2 * np.pi / (2 * np.pi / EP['dres']))
+        num=EP['dres'])
 
     #calculate transfer parameters
     print('transfer parameters\n')


### PR DESCRIPTION
Currently the code multiplies and then divides by 2π when generating the direction array. This unnecessary operation casts the result to float, which raises an error in `np.linspace`. Removing the multiply/divide keeps the original dtype from `EP['dres']` which should be int.